### PR TITLE
Alternate fix for adding -lintl to command line

### DIFF
--- a/var/spack/repos/builtin/packages/cryptsetup/autotools-libintl.patch
+++ b/var/spack/repos/builtin/packages/cryptsetup/autotools-libintl.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am	2019-09-11 10:38:34.587418453 -0700
++++ b/Makefile.am	2019-09-11 10:32:45.715961308 -0700
+@@ -13,7 +13,7 @@
+         -DSYSCONFDIR=\""$(sysconfdir)"\"        \
+         -DVERSION=\""$(VERSION)"\"
+ AM_CFLAGS = -Wall
+-AM_LDFLAGS =
++AM_LDFLAGS = @LTLIBINTL@
+ 
+ tmpfilesddir = @DEFAULT_TMPFILESDIR@
+ 

--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -23,13 +23,21 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('util-linux', type=('build', 'link'))
     depends_on('gettext', type=('build', 'link'))
 
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+
+    # Upstream includes support for discovering the location of the libintl library
+    # but is missing the bit in the Makefile.ac that includes it in the LDFLAGS.
+    patch('autotools-libintl.patch')
+
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/cryptsetup/v{0}/cryptsetup-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
     def configure_args(self):
         args = [
-            'LIBS=-lintl',
             'systemd_tmpfilesdir={0}/tmpfiles.d'.format(self.prefix)
         ]
         return args


### PR DESCRIPTION
Upstream includes support for discovering the location of the libintl library
but is missing the bit in the Makefile.ac that includes it in the LDFLAGS.

This adds a patch to the package, the patch adds the value of LTLIBINTL (which
configure populates for us) to AM_LDFLAGS, which eventually find their
way into the LDFLAGS, et viola!

This commit also adds the prior method of explicitly setting the LIBS variable.

Additional information here: https://www.gnu.org/software/gettext/manual/html_node/AM_005fGNU_005fGETTEXT.html